### PR TITLE
Dynamic size

### DIFF
--- a/lua/data-viewer.lua
+++ b/lua/data-viewer.lua
@@ -54,10 +54,11 @@ M.start = function(opts)
   local headerStr, headerInfo = module.get_win_header_str(parsedData)
   for tableName, tableData in pairs(parsedData) do
     parsedData[tableName]["colMaxWidth"] = module.get_max_width(tableData.headers, tableData.bodyLines)
-    parsedData[tableName]["formatedLines"] = utils.merge_array(
-      { headerStr },
-      module.format_lines(tableData.headers, tableData.bodyLines, tableData["colMaxWidth"])
-    )
+
+    
+    local formatedLines = module.format_lines(tableData.headers, tableData.bodyLines, tableData["colMaxWidth"])
+    parsedData[tableName]["formatedLines"] = utils.merge_array( { headerStr }, formatedLines)
+    parsedData[tableName]["width"] = #formatedLines[1]
   end
 
   local first_bufnum = -1
@@ -65,7 +66,7 @@ M.start = function(opts)
 
   M.parsed_data = parsedData
   M.header_info = headerInfo
-  M.win_id = module.open_win { first_bufnum, opts.force_replace }
+  M.win_id = module.open_win(first_bufnum, opts.force_replace)
 
   for _, header in ipairs(M.header_info) do
     local bufnum = parsedData[header.name].bufnum

--- a/lua/data-viewer/config.lua
+++ b/lua/data-viewer/config.lua
@@ -32,6 +32,7 @@ local DefaultConfig = {
   maxLineEachTable = 100,
   columnColorEnable = true,
   columnColorRoulette = { "DataViewerColumn0", "DataViewerColumn1", "DataViewerColumn2" },
+  modifiable = false,
   view = ViewConfig,
   keymap = KeymapConfig,
 }

--- a/lua/data-viewer/module.lua
+++ b/lua/data-viewer/module.lua
@@ -105,7 +105,15 @@ M.create_bufs = function(tablesData)
   for tableName, tableData in pairs(tablesData) do
     local buf = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, tableData.formatedLines)
-    vim.api.nvim_buf_set_option(buf, "modifiable", false)
+    vim.api.nvim_buf_set_option(buf, "modifiable", config.config.modifiable)
+    if config.config.modifiable then
+      vim.api.nvim_create_autocmd({"TextChanged", "TextChangedI"}, {
+        buffer = buf,
+        callback = function(ev) 
+          vim.api.nvim_buf_set_lines(buf, 0, -1, false, tableData.formatedLines)
+        end
+      })
+    end
     vim.api.nvim_buf_set_name(buf, "DataViwer-" .. tableName)
     vim.api.nvim_buf_set_keymap(buf, "n", config.config.keymap.next_table, ":DataViewerNextTable<CR>", KEYMAP_OPTS)
     vim.api.nvim_buf_set_keymap(buf, "n", config.config.keymap.prev_table, ":DataViewerPrevTable<CR>", KEYMAP_OPTS)


### PR DESCRIPTION
This pull request introduces several updates to the `lua/data-viewer` module, focusing on enhancing configurability, improving buffer handling, and refining function signatures. The changes include making buffers optionally modifiable, adding dynamic window dimensions for floating views, and cleaning up function arguments to improve clarity.

### Enhancements to configurability:
* Added a new `modifiable` option in the default configuration (`lua/data-viewer/config.lua`). This allows buffers to be optionally modifiable, enabling users to make changes within the buffer if desired.
* Updated `M.create_bufs` to respect the `modifiable` configuration. If enabled, it sets up autocmds to reset buffer lines upon changes.

### Improvements to buffer handling:
* Introduced dynamic column and line dimensions for floating views in `M.create_bufs`, based on table data width and body line count.
* Cleaned up the `M.open_win` function by replacing the `opts` table parameter with explicit arguments (`buf_id` and `force_replace`) for better readability.

### Code cleanup and minor refinements:
* Added a return type annotation for the `M.format_lines` function to improve code clarity and maintainability.
* Commented out unused width and height properties in the floating window configuration, likely as part of a work-in-progress or debugging effort.